### PR TITLE
Use a single branch for generic Epiverse & EpiTKit theme

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,7 @@
 # lc: Library Carpentry
 # cp: Carpentries (to use for instructor training for instance)
 # incubator: The Carpentries Incubator
-carpentry: 'incubator'
+carpentry: 'epitkit'
 
 # Overall title for pages.
 title: 'Curso en ciencia de datos en salud pública y modelamiento de enfermedades infecciosas'
@@ -81,7 +81,7 @@ profiles:
 #
 # This space below is where custom yaml items (e.g. pinning
 # sandpaper and varnish versions) should live
-varnish: epiverse-trace/varnish@epitkit
+varnish: epiverse-trace/varnish@epiversetheme
 # this is carpentries/sandpaper#533 in our fork so we can keep it up to date with main
 sandpaper: epiverse-trace/sandpaper@patch-renv-github-bug
 lang: es


### PR DESCRIPTION
This will allow me to only have to maintain https://github.com/epiverse-trace/varnish/pull/7 and not https://github.com/epiverse-trace/varnish/pull/7 & https://github.com/epiverse-trace/varnish/pull/11.
