### PR TITLE
agregar comentario sobre aviso al resumir agrupamiento con dos variables

### DIFF
--- a/episodes/Visualizacion.Rmd
+++ b/episodes/Visualizacion.Rmd
@@ -228,6 +228,46 @@ covid19_resumen <- covid19 %>%
   summarise(casos = n())
 ```
 
+Notemos que el mensaje de salida nos notifica que
+luego de usar `summarise()` se ha removido
+una variable del agrupamiento previamente configudado por `group_by()`.
+Esto es porque la segunda variable ("sexo") es ahora una sola fila
+dentro de la variable de agrupamiento ("fecha_reporte_web").
+Veamos el resultado de la operación anterior:
+
+```{r}
+covid19_resumen
+```
+
+También podemos verificar el motivo del mensaje usando la función `dplyr::group_vars()`.
+
+::::::::: spoiler
+
+Exploremos el paso a paso usando la función `dplyr::group_vars()`:
+
+```{r}
+# Agrupar por "fecha" y "sexo"
+# Con dplyr::group_vars() confirmamos agrupamiento
+covid19 %>%
+  dplyr::group_by(fecha_reporte_web, sexo) %>%
+  dplyr::group_vars()
+
+# Resuminos por "fecha" y "sexo"
+# Con dplyr::group_vars() confirmamos que
+# luego de usar dplyr::summarise()
+# removemos la última variable de agrupamiento ("sexo")
+# debido a que ese grupo es ahora una sola fila por cada "fecha".
+covid19 %>%
+  dplyr::group_by(fecha_reporte_web, sexo) %>% 
+  dplyr::summarise(casos = n()) %>% 
+  dplyr::group_vars()
+```
+
+Este es el resultado por defecto.
+Puedes ver las opciones disponibles usando el [argumento `.groups` dentro de la función `summarise()`](https://dplyr.tidyverse.org/reference/summarise.html#arg--groups).
+
+:::::::::
+
 Luego, podemos usar la estética de los gráficos de `ggplot2` indicando
 las variables a usar en cada dimensión, en este caso en el eje X
 tendremos la variable de tiempo (fecha_reporte_web) y en el eje Y el
@@ -504,6 +544,17 @@ contar el número de casos por `edad` y `sexo`:
 covid19_sexo <- covid19 %>%
   group_by(edad, sexo) %>%
   summarise(casos = n())
+```
+
+Notemos nuevamente que el mensaje de salida nos notifica que
+luego de usar `summarise()` se ha removido la última
+variable del agrupamiento previamente configudado por `group_by()`.
+Esto es porque la segunda variable ("sexo") es ahora una sola fila
+dentro de la variable de agrupamiento ("edad").
+Veamos el resultado de la operación anterior:
+
+```{r}
+covid19_sexo
 ```
 
 Usando los datos de `covid-19`, vamos a representar la variable `casos`


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] I have read the CONTRIBUTING guidelines
- [x] Checks have been run locally and pass

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Agregamos parrafo y pestaña desplegable para comentar sobre el mensaje de salida al agrupar dos variables y luego usar summarise(), funcion que remueve la ultima variable de resumen.

```
`summarise()` has grouped output by 'edad'. You can override using the `.groups` argument.
```

Secciones del tutorial con este mensaje:
- https://epiverse-trace.github.io/epitkit/Visualizacion.html#ejemplo-1-gr%C3%A1fico-de-dispersi%C3%B3n-scatter-plot
- https://epiverse-trace.github.io/epitkit/Visualizacion.html#ejemplo-5--gr%C3%A1fico-con-facet-wrap


* **Other information**:

Esto permitira apoyar a instructores en la aclaracion las dudas que surjan en este paso. Propuesto luego de consulta por @lgbermeo 

reprex de soporte

``` r
# importar librerias
library(tidyverse)

# leer datos
covid19 <- readr::read_rds("http://epiverse-trace.github.io/epitkit/data/muestra_covid.RDS")

# agrupar por "edad" y "sexo"
# con dplyr::group_vars() confirmamos agrupamiento
covid19 %>%
  dplyr::group_by(edad, sexo) %>%
  dplyr::group_vars()
#> [1] "edad" "sexo"

# resuminos por "edad" y "sexo"
# con dplyr::group_vars() confirmamos que
# luego de usar dplyr::summarise()
# removemos una variable de agrupamiento
# (debido a que ese grupo es ahora una sola fila)
covid19 %>%
  dplyr::group_by(edad, sexo) %>% 
  dplyr::summarise(casos = n()) %>% 
  dplyr::group_vars()
#> `summarise()` has grouped output by 'edad'. You can override using the
#> `.groups` argument.
#> [1] "edad"
```

<sup>Created on 2025-09-05 with [reprex v2.1.1](https://reprex.tidyverse.org/)</sup>